### PR TITLE
Fix: Samsung Internet PWA 설치 이슈 해결

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,4 +1,5 @@
 {
+  "id": "/",
   "name": "한국어 어휘 학습 노트",
   "short_name": "한국어학습",
   "description": "러시아인을 위한 AI 기반 한국어 어휘 학습 도구",
@@ -45,7 +46,13 @@
       "src": "/static/icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/static/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/static/icons/icon-384.png",
@@ -57,7 +64,13 @@
       "src": "/static/icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/static/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ],
   "screenshots": [

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,7 +1,8 @@
 // Service Worker for Korean Vocabulary Learning App
-const CACHE_NAME = 'korean-vocab-v1.0.0';
-const STATIC_CACHE = 'static-v1.0.0';
-const DYNAMIC_CACHE = 'dynamic-v1.0.0';
+// Samsung Internet 호환성 개선
+const CACHE_NAME = 'korean-vocab-v1.0.1';
+const STATIC_CACHE = 'static-v1.0.1';
+const DYNAMIC_CACHE = 'dynamic-v1.0.1';
 
 // 캐시할 정적 리소스 목록
 const STATIC_ASSETS = [
@@ -9,7 +10,9 @@ const STATIC_ASSETS = [
   '/static/style.css',
   '/static/script.js',
   '/static/manifest.json',
-  // 폰트 및 기타 정적 리소스는 필요시 추가
+  '/static/icons/icon-192.png',
+  '/static/icons/icon-512.png',
+  // Samsung Internet 호환성을 위한 필수 아이콘 추가
 ];
 
 // 캐시할 API 엔드포인트 패턴

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <title>한국어 어휘 학습 노트</title>
     
     <!-- PWA Manifest -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/static/manifest.json">
     
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#667eea">


### PR DESCRIPTION
## Summary
Samsung Internet 브라우저에서 PWA 설치가 되지 않는 문제를 해결했습니다.

• **manifest.json에 Samsung Internet 필수 'id' 필드 추가**
• **아이콘 purpose 속성 분리**: "any maskable" → "any"와 "maskable" 별도 설정
• **HTML manifest 경로 수정**: `/manifest.json` → `/static/manifest.json`
• **서비스 워커 최적화**: 캐시 버전 업데이트 및 필수 아이콘 캐싱 추가

## Test plan
- [x] manifest.json 구문 검증 완료
- [x] HTML manifest 링크 경로 수정 완료  
- [x] 서비스 워커 캐시 전략 개선 완료
- [ ] Samsung Internet에서 PWA 설치 테스트 필요
- [ ] Chrome/Firefox 기존 기능 회귀 테스트 필요

## 기대 효과
- Samsung Internet 사용자들이 PWA를 홈화면에 설치 가능
- 브라우저 간 PWA 호환성 개선
- 사용자 경험 향상

🤖 Generated with [Claude Code](https://claude.ai/code)