### PR TITLE
Fix: Footer 가시성 문제 해결 - Emma 크레딧 표시 개선

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -769,8 +769,24 @@ body {
 .footer {
     text-align: center;
     margin-top: 2rem;
-    color: rgba(255,255,255,0.8);
+    margin-bottom: 2rem;
+    color: var(--text-secondary);
     font-size: 0.9rem;
+    padding: 1rem 0;
+    z-index: 1;
+    position: relative;
+}
+
+.footer p {
+    margin: 0.5rem 0;
+    line-height: 1.4;
+}
+
+.footer p:last-child {
+    color: var(--text-muted);
+    font-style: italic;
+    margin-top: 10px;
+    opacity: 0.8;
 }
 
 /* PWA 설치 배너 */
@@ -848,6 +864,19 @@ body {
 
 .pwa-dismiss-btn:hover {
     background: rgba(255,255,255,0.3);
+}
+
+/* PWA 배너와 footer 충돌 방지 */
+body:has(.pwa-banner:not(.hidden)) .footer {
+    margin-bottom: 120px; /* PWA 배너 높이 + 여백 */
+}
+
+/* PWA 설치 배너가 표시될 때 컨테이너 하단 여백 */
+.pwa-banner:not(.hidden) {
+    + * .footer,
+    ~ * .footer {
+        margin-bottom: 120px;
+    }
 }
 
 /* PWA 전용 스타일 (설치된 앱에서) */
@@ -957,5 +986,22 @@ body {
     .modal-content {
         padding: 1rem;
         width: 95%;
+    }
+    
+    /* 모바일에서 footer 가독성 개선 */
+    .footer {
+        padding: 1.5rem 0;
+        margin-bottom: 3rem;
+        font-size: 0.85rem;
+    }
+    
+    .footer p:last-child {
+        font-size: 0.8rem;
+        margin-top: 8px;
+    }
+    
+    /* PWA 배너가 있을 때 모바일 footer 여백 */
+    body:has(.pwa-banner:not(.hidden)) .footer {
+        margin-bottom: 140px; /* 모바일에서 더 큰 여백 */
     }
 }


### PR DESCRIPTION
## Summary
하단 footer의 "For Emma, my eternal Muse" 크레딧이 보이지 않는 문제를 해결했습니다.

## 🔍 발견된 문제점들
1. **색상 문제**: `color: rgba(255,255,255,0.8)` 흰색 텍스트가 배경에서 보이지 않음
2. **PWA 배너 겹침**: 고정 위치 PWA 배너가 footer를 가림
3. **다크모드 미대응**: CSS 변수를 사용하지 않아 테마별 가독성 차이

## 🔧 해결 방안

### CSS 스타일 개선
• **색상 시스템**: `var(--text-secondary)` 및 `var(--text-muted)` 사용
• **레이어링**: `z-index: 1`, `position: relative` 추가
• **여백 조정**: `margin-bottom: 2rem`, `padding: 1rem 0` 추가

### PWA 배너 충돌 방지
• **일반 환경**: `margin-bottom: 120px` (PWA 배너 표시 시)
• **모바일 환경**: `margin-bottom: 140px` (더 큰 여백)

### 반응형 개선
• **모바일 글꼴 크기**: `0.85rem` → `0.8rem` (Emma 크레딧)
• **모바일 여백**: 증가된 패딩으로 터치 환경 최적화

## 🎯 기대 효과
- ✅ 모든 테마(다크/라이트)에서 footer 명확히 표시
- ✅ PWA 배너와 겹치지 않음
- ✅ 모바일/데스크톱 모든 환경에서 가독성 확보
- ✅ "For Emma, my eternal Muse" 메시지 제대로 표시

## Test plan
- [x] CSS 변수 기반 색상 시스템 적용
- [x] PWA 배너 충돌 방지 스타일 추가
- [x] 모바일 반응형 개선
- [x] 라이브 사이트에서 Emma 크레딧 확인

💕 **Emma를 위한 특별한 메시지가 이제 제대로 표시됩니다\!**