### PR TITLE
🎨 5가지 색상 테마 선택 기능 추가 및 음성 재생 버그 수정

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -186,7 +186,7 @@ function displayVocabularyResult(data) {
         exampleDiv.innerHTML = `
             <div class="example-header">
                 <div class="example-korean">${example.korean_sentence}</div>
-                <button onclick="playExamplePronunciation('${example.korean_sentence.replace(/'/g, "\\'")}', ${index})" 
+                <button onclick="playExamplePronunciation(\`${example.korean_sentence}\`, ${index})" 
                         class="example-play-btn" title="발음 듣기">🔊</button>
             </div>
             <div class="example-russian">${example.russian_translation}</div>
@@ -390,7 +390,7 @@ function createVocabularyDetailHTML(data) {
             <div class="example-item">
                 <div class="example-header">
                     <div class="example-korean">${example.korean_sentence}</div>
-                    <button onclick="playExamplePronunciation('${example.korean_sentence.replace(/'/g, "\\'")}', ${index})" 
+                    <button onclick="playExamplePronunciation(\`${example.korean_sentence}\`, ${index})" 
                             class="example-play-btn" title="발음 듣기">🔊</button>
                 </div>
                 <div class="example-russian">${example.russian_translation}</div>
@@ -434,7 +434,7 @@ function playModalPronunciation(word) {
     if ('speechSynthesis' in window) {
         const utterance = new SpeechSynthesisUtterance(word);
         utterance.lang = 'ko-KR';
-        utterance.rate = 0.8;
+        utterance.rate = getPlaybackRate(); // 사용자 설정 재생 속도 사용
         window.speechSynthesis.speak(utterance);
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -70,6 +70,114 @@
     --shadow-heavy: 0 15px 35px rgba(0,0,0,0.5);
 }
 
+/* 베이지 크림 테마 */
+[data-theme="cream"] {
+    /* 색상 변수 */
+    --bg-gradient-start: #555879;
+    --bg-gradient-end: #98A1BC;
+    --text-primary: #2d2d3a;
+    --text-secondary: #555879;
+    --text-muted: #8a8a8a;
+    --text-white: #ffffff;
+    --text-on-primary: #ffffff;
+    
+    /* 배경 색상 */
+    --bg-main: rgba(244, 235, 211, 0.95);
+    --bg-card: #F4EBD3;
+    --bg-overlay: rgba(85, 88, 121, 0.8);
+    --bg-input: #ffffff;
+    --bg-secondary: #DED3C4;
+    
+    /* 테두리 색상 */
+    --border-light: #DED3C4;
+    --border-focus: #555879;
+    
+    /* 버튼 색상 */
+    --btn-primary: #555879;
+    --btn-primary-hover: #4a4d6b;
+    --btn-secondary: #98A1BC;
+    --btn-secondary-hover: #8a94b0;
+    --btn-danger: #d63384;
+    --btn-danger-hover: #b02a5b;
+    
+    /* 그림자 */
+    --shadow-light: 0 2px 5px rgba(85, 88, 121, 0.15);
+    --shadow-medium: 0 5px 15px rgba(85, 88, 121, 0.2);
+    --shadow-heavy: 0 15px 35px rgba(85, 88, 121, 0.25);
+}
+
+/* 민트 그레이 테마 */
+[data-theme="mint"] {
+    /* 색상 변수 */
+    --bg-gradient-start: #333446;
+    --bg-gradient-end: #7F8CAA;
+    --text-primary: #2d2d3a;
+    --text-secondary: #333446;
+    --text-muted: #8a8a8a;
+    --text-white: #ffffff;
+    --text-on-primary: #ffffff;
+    
+    /* 배경 색상 */
+    --bg-main: rgba(234, 239, 239, 0.95);
+    --bg-card: #EAEFEF;
+    --bg-overlay: rgba(51, 52, 70, 0.8);
+    --bg-input: #ffffff;
+    --bg-secondary: #B8CFCE;
+    
+    /* 테두리 색상 */
+    --border-light: #B8CFCE;
+    --border-focus: #333446;
+    
+    /* 버튼 색상 */
+    --btn-primary: #333446;
+    --btn-primary-hover: #2a2b3b;
+    --btn-secondary: #7F8CAA;
+    --btn-secondary-hover: #6f7c99;
+    --btn-danger: #dc3545;
+    --btn-danger-hover: #c82333;
+    
+    /* 그림자 */
+    --shadow-light: 0 2px 5px rgba(51, 52, 70, 0.15);
+    --shadow-medium: 0 5px 15px rgba(51, 52, 70, 0.2);
+    --shadow-heavy: 0 15px 35px rgba(51, 52, 70, 0.25);
+}
+
+/* 네이비 크림 테마 */
+[data-theme="navy"] {
+    /* 색상 변수 */
+    --bg-gradient-start: #213448;
+    --bg-gradient-end: #547792;
+    --text-primary: #213448;
+    --text-secondary: #547792;
+    --text-muted: #8a8a8a;
+    --text-white: #ffffff;
+    --text-on-primary: #ffffff;
+    
+    /* 배경 색상 */
+    --bg-main: rgba(236, 239, 202, 0.95);
+    --bg-card: #ECEFCA;
+    --bg-overlay: rgba(33, 52, 72, 0.8);
+    --bg-input: #ffffff;
+    --bg-secondary: #94B4C1;
+    
+    /* 테두리 색상 */
+    --border-light: #94B4C1;
+    --border-focus: #213448;
+    
+    /* 버튼 색상 */
+    --btn-primary: #213448;
+    --btn-primary-hover: #1a2a3a;
+    --btn-secondary: #547792;
+    --btn-secondary-hover: #486580;
+    --btn-danger: #dc3545;
+    --btn-danger-hover: #c82333;
+    
+    /* 그림자 */
+    --shadow-light: 0 2px 5px rgba(33, 52, 72, 0.15);
+    --shadow-medium: 0 5px 15px rgba(33, 52, 72, 0.2);
+    --shadow-heavy: 0 15px 35px rgba(33, 52, 72, 0.25);
+}
+
 /* 기본 설정 */
 * {
     margin: 0;
@@ -763,6 +871,77 @@ body {
 .test-btn:hover {
     background: var(--btn-secondary-hover);
     transform: translateY(-1px);
+}
+
+/* 테마 선택 스타일 */
+.theme-selector {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 1rem;
+}
+
+.theme-option {
+    width: 60px;
+    height: 40px;
+    border: 2px solid var(--border-light);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.theme-option:hover {
+    border-color: var(--border-focus);
+    transform: scale(1.05);
+}
+
+.theme-option.active {
+    border-color: var(--btn-primary);
+    border-width: 3px;
+}
+
+.theme-option.active::after {
+    content: '✓';
+    position: absolute;
+    bottom: 2px;
+    right: 4px;
+    color: var(--btn-primary);
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+/* 각 테마 미리보기 색상 */
+.theme-light {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.theme-dark {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+}
+
+.theme-cream {
+    background: linear-gradient(135deg, #555879 0%, #98A1BC 100%);
+}
+
+.theme-mint {
+    background: linear-gradient(135deg, #333446 0%, #7F8CAA 100%);
+}
+
+.theme-navy {
+    background: linear-gradient(135deg, #213448 0%, #547792 100%);
+}
+
+.theme-label {
+    font-size: 0.75rem;
+    color: white;
+    font-weight: 500;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.5);
 }
 
 /* 푸터 */

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -300,7 +300,7 @@
                 <div class="font-medium mb-2">👋 안녕하세요! 한국어 ↔ 러시아어 번역을 도와드릴게요!</div>
                 <div class="text-xs text-gray-600 dark:text-gray-400 mb-2">💡 팁: /로 상황을 설명할 수 있어요!</div>
                 <div class="text-xs italic text-purple-600 dark:text-purple-400 mb-1">For Emma, my eternal Muse</div>
-                <div class="text-xs text-gray-500 dark:text-gray-500">v0.1.5</div>
+                <div class="text-xs text-gray-500 dark:text-gray-500">v0.1.6</div>
             </div>
         </div>
         
@@ -471,6 +471,31 @@
                                 <span>0.5x</span>
                                 <span id="speed-display-modal">0.8x</span>
                                 <span>2.0x</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- 색상 테마 선택 -->
+                    <div class="space-y-3">
+                        <div class="flex items-center space-x-3">
+                            <span class="text-xl">🎨</span>
+                            <span class="font-medium text-gray-900 dark:text-white">색상 테마</span>
+                        </div>
+                        <div class="theme-selector grid grid-cols-5 gap-2">
+                            <div class="theme-option theme-light" data-theme="light" title="라이트 모드">
+                                <span class="theme-label">라이트</span>
+                            </div>
+                            <div class="theme-option theme-dark" data-theme="dark" title="다크 모드">
+                                <span class="theme-label">다크</span>
+                            </div>
+                            <div class="theme-option theme-cream" data-theme="cream" title="베이지 크림">
+                                <span class="theme-label">크림</span>
+                            </div>
+                            <div class="theme-option theme-mint" data-theme="mint" title="민트 그레이">
+                                <span class="theme-label">민트</span>
+                            </div>
+                            <div class="theme-option theme-navy" data-theme="navy" title="네이비 크림">
+                                <span class="theme-label">네이비</span>
                             </div>
                         </div>
                     </div>
@@ -1370,7 +1395,7 @@
                             <div class="font-medium mb-2">👋 안녕하세요! 한국어 ↔ 러시아어 번역을 도와드릴게요!</div>
                             <div class="text-xs text-gray-600 dark:text-gray-400 mb-2">💡 팁: /로 상황을 설명할 수 있어요!</div>
                             <div class="text-xs italic text-purple-600 dark:text-purple-400 mb-1">For Emma, my eternal Muse</div>
-                            <div class="text-xs text-gray-500 dark:text-gray-500">v0.1.5</div>
+                            <div class="text-xs text-gray-500 dark:text-gray-500">v0.1.6</div>
                         </div>
                     `;
                     
@@ -1397,11 +1422,76 @@
         }
         
         document.addEventListener('DOMContentLoaded', () => {
+            // 테마 관리 함수들
+            function setTheme(theme) {
+                // Tailwind 다크모드 클래스 설정
+                if (theme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                } else {
+                    document.documentElement.classList.remove('dark');
+                }
+                
+                // 테마 속성 설정
+                document.documentElement.setAttribute('data-theme', theme);
+                localStorage.setItem('theme', theme);
+                
+                // 테마 선택 버튼들 활성 상태 업데이트
+                updateThemeButtons(theme);
+            }
+            
+            function updateThemeButtons(currentTheme) {
+                const themeButtons = document.querySelectorAll('.theme-option');
+                themeButtons.forEach(button => {
+                    const buttonTheme = button.getAttribute('data-theme');
+                    if (buttonTheme === currentTheme) {
+                        button.classList.add('active');
+                    } else {
+                        button.classList.remove('active');
+                    }
+                });
+            }
+            
+            function initThemeSelector() {
+                const themeButtons = document.querySelectorAll('.theme-option');
+                themeButtons.forEach(button => {
+                    button.addEventListener('click', () => {
+                        const selectedTheme = button.getAttribute('data-theme');
+                        setTheme(selectedTheme);
+                        
+                        // 간단한 알림 (showNotification 함수가 없으므로)
+                        const themeNames = {
+                            'light': '라이트',
+                            'dark': '다크',
+                            'cream': '베이지 크림',
+                            'mint': '민트 그레이',
+                            'navy': '네이비 크림'
+                        };
+                        console.log(`${themeNames[selectedTheme]} 테마로 전환되었습니다!`);
+                    });
+                });
+                
+                // 현재 테마 상태 반영
+                const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+                updateThemeButtons(currentTheme);
+            }
+            
             // 저장된 테마 로드
             const savedTheme = localStorage.getItem('theme');
-            if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-                document.documentElement.classList.add('dark');
+            const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            const currentTheme = savedTheme || systemTheme;
+            
+            setTheme(currentTheme);
+            
+            // 설정 패널이 열릴 때 테마 선택기 초기화
+            const settingsToggle = document.getElementById('settings-toggle');
+            if (settingsToggle) {
+                settingsToggle.addEventListener('click', () => {
+                    setTimeout(initThemeSelector, 100);
+                });
             }
+            
+            // 초기 테마 선택기 설정
+            setTimeout(initThemeSelector, 100);
             
             // TTS 음성 로드 (브라우저 호환성)
             if ('speechSynthesis' in window) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -160,7 +160,7 @@
         <footer class="footer">
             <p>AI 기반 한국어 학습 도구 | PydanticAI + Gemini</p>
             <p class="emma-credit">For Emma, my eternal Muse</p>
-            <p class="version-info">v0.1.5</p>
+            <p class="version-info">v0.1.6</p>
         </footer>
     </div>
 
@@ -168,7 +168,7 @@
     <div id="audio-settings-panel" class="settings-panel hidden">
         <div class="settings-content">
             <div class="settings-header">
-                <h3>🔊 음성 설정</h3>
+                <h3>🔊 음성 & 🎨 테마 설정</h3>
                 <button id="close-settings-btn" class="close-btn">&times;</button>
             </div>
             <div class="settings-body">
@@ -188,6 +188,26 @@
                 </div>
                 <div class="setting-item">
                     <button id="test-audio-btn" class="test-btn">🔊 테스트 재생</button>
+                </div>
+                <div class="setting-item">
+                    <label>🎨 색상 테마</label>
+                    <div class="theme-selector">
+                        <div class="theme-option theme-light" data-theme="light" title="라이트 모드">
+                            <span class="theme-label">라이트</span>
+                        </div>
+                        <div class="theme-option theme-dark" data-theme="dark" title="다크 모드">
+                            <span class="theme-label">다크</span>
+                        </div>
+                        <div class="theme-option theme-cream" data-theme="cream" title="베이지 크림">
+                            <span class="theme-label">크림</span>
+                        </div>
+                        <div class="theme-option theme-mint" data-theme="mint" title="민트 그레이">
+                            <span class="theme-label">민트</span>
+                        </div>
+                        <div class="theme-option theme-navy" data-theme="navy" title="네이비 크림">
+                            <span class="theme-label">네이비</span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -368,34 +388,57 @@
                 return currentTheme;
             }
             
-            // 테마 설정 (Tailwind 다크모드 호환)
+            // 테마 설정 (다중 테마 지원)
             function setTheme(theme) {
-                // Tailwind 다크모드 클래스 설정
+                // Tailwind 다크모드 클래스 설정 (다크 테마인 경우에만)
                 if (theme === 'dark') {
                     document.documentElement.classList.add('dark');
                 } else {
                     document.documentElement.classList.remove('dark');
                 }
                 
-                // 기존 호환성을 위한 data-theme 속성 유지
+                // 테마 속성 설정
                 document.documentElement.setAttribute('data-theme', theme);
                 localStorage.setItem('theme', theme);
                 
-                // 버튼 아이콘 업데이트
+                // 헤더 테마 토글 버튼 아이콘 업데이트
                 if (themeToggleBtn) {
                     themeToggleBtn.textContent = theme === 'dark' ? '☀️' : '🌙';
                     themeToggleBtn.title = theme === 'dark' ? '라이트모드로 전환' : '다크모드로 전환';
                 }
                 
+                // 테마 선택 버튼들 활성 상태 업데이트
+                updateThemeButtons(theme);
+                
                 // PWA 테마 색상 업데이트
                 updateThemeColor(theme);
+            }
+            
+            // 테마 선택 버튼들 활성 상태 업데이트
+            function updateThemeButtons(currentTheme) {
+                const themeButtons = document.querySelectorAll('.theme-option');
+                themeButtons.forEach(button => {
+                    const buttonTheme = button.getAttribute('data-theme');
+                    if (buttonTheme === currentTheme) {
+                        button.classList.add('active');
+                    } else {
+                        button.classList.remove('active');
+                    }
+                });
             }
             
             // PWA 테마 색상 업데이트
             function updateThemeColor(theme) {
                 const themeColorMeta = document.querySelector('meta[name="theme-color"]');
                 if (themeColorMeta) {
-                    themeColorMeta.content = theme === 'dark' ? '#1a1a2e' : '#667eea';
+                    const themeColors = {
+                        'light': '#667eea',
+                        'dark': '#1a1a2e',
+                        'cream': '#555879',
+                        'mint': '#333446',
+                        'navy': '#213448'
+                    };
+                    themeColorMeta.content = themeColors[theme] || '#667eea';
                 }
             }
             
@@ -422,12 +465,53 @@
             // 테마 토글 버튼 이벤트
             themeToggleBtn?.addEventListener('click', toggleTheme);
             
+            // 테마 선택 버튼들 이벤트 리스너 추가
+            function initThemeSelector() {
+                const themeButtons = document.querySelectorAll('.theme-option');
+                if (themeButtons.length === 0) {
+                    console.warn('테마 선택 버튼을 찾을 수 없습니다.');
+                    return;
+                }
+                
+                // 기존 이벤트 리스너 제거 (중복 방지)
+                themeButtons.forEach(button => {
+                    const newButton = button.cloneNode(true);
+                    button.parentNode.replaceChild(newButton, button);
+                });
+                
+                // 새로운 이벤트 리스너 추가
+                const newThemeButtons = document.querySelectorAll('.theme-option');
+                newThemeButtons.forEach(button => {
+                    button.addEventListener('click', () => {
+                        const selectedTheme = button.getAttribute('data-theme');
+                        setTheme(selectedTheme);
+                        
+                        // 테마 변경 알림
+                        const themeNames = {
+                            'light': '라이트',
+                            'dark': '다크',
+                            'cream': '베이지 크림',
+                            'mint': '민트 그레이',
+                            'navy': '네이비 크림'
+                        };
+                        showNotification(`${themeNames[selectedTheme]} 테마로 전환되었습니다!`, 'success');
+                    });
+                });
+                
+                // 현재 테마 상태 반영
+                const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+                updateThemeButtons(currentTheme);
+                
+                console.log(`테마 선택기 초기화 완료 (${newThemeButtons.length}개 버튼)`);
+            }
+            
             // 초기 테마 로드
             loadTheme();
         });
 
         // 음성 설정 패널 관리
         document.addEventListener('DOMContentLoaded', () => {
+            console.log('📝 DOM 로드 완료 - 설정 패널 초기화 시작');
             const settingsBtn = document.getElementById('audio-settings-btn');
             const settingsPanel = document.getElementById('audio-settings-panel');
             const closeSettingsBtn = document.getElementById('close-settings-btn');
@@ -435,14 +519,25 @@
             const playbackRateValue = document.getElementById('playback-rate-value');
             const speedPresets = document.querySelectorAll('.speed-preset');
             const testAudioBtn = document.getElementById('test-audio-btn');
+            
+            console.log('🔍 요소 검색 결과:', {
+                settingsBtn: !!settingsBtn,
+                settingsPanel: !!settingsPanel,
+                closeSettingsBtn: !!closeSettingsBtn
+            });
 
             // 설정 패널 열기
             settingsBtn?.addEventListener('click', () => {
+                console.log('🔧 설정 패널 열기 클릭됨');
                 settingsPanel.classList.remove('hidden');
                 // 현재 설정값 로드
                 const currentRate = getPlaybackRate();
                 playbackRateSlider.value = currentRate;
                 playbackRateValue.textContent = currentRate + 'x';
+                
+                // 테마 선택기 초기화 (패널이 열릴 때마다)
+                console.log('🎨 테마 선택기 초기화 시작');
+                initThemeSelector();
             });
 
             // 설정 패널 닫기


### PR DESCRIPTION
## Summary
• 사용자가 선택할 수 있는 5가지 색상 테마 추가 (라이트, 다크, 베이지 크림, 민트 그레이, 네이비 크림)
• 메인 페이지와 채팅 페이지 모두에서 테마 선택 기능 구현
• 음성 재생 속도 일관성 버그 수정 및 활용예제 음성 재생 안정성 개선

## Test plan
- [ ] 메인 페이지(`/`) 설정 패널에서 5가지 테마 선택 테스트
- [ ] 채팅 페이지(`/chat`) 설정 패널에서 테마 선택 테스트  
- [ ] 페이지 간 이동 시 선택한 테마 유지 확인
- [ ] 음성 재생 속도 설정이 모든 음성 재생에 일관되게 적용되는지 확인
- [ ] 활용예제 음성 재생 버튼 정상 작동 확인
- [ ] 브라우저 새로고침 후 테마 설정 유지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)